### PR TITLE
Add scroll-reveal animations for new layer

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -94,10 +94,13 @@ body {
 
 .layer-new .fade-down,
 .layer-new .fade-up-container,
-.layer-new .about-me,
+.layer-new .about-me {
+  opacity: 1 !important;
+  transform: none !important;
+  animation: none !important;
+}
+
 .layer-new .greeting {
-  opacity: unset;
-  transform: unset;
   animation: none !important;
 }
 
@@ -715,6 +718,164 @@ body {
   background: currentColor;
 }
 
+
+/* ── New-layer scroll reveal animations ── */
+
+.layer-new [data-reveal] {
+  opacity: 0;
+  will-change: opacity, transform, filter;
+  transition:
+    opacity 750ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 750ms cubic-bezier(0.22, 1, 0.36, 1),
+    filter 750ms cubic-bezier(0.22, 1, 0.36, 1),
+    clip-path 750ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* ---- slide variants ---- */
+.layer-new [data-reveal="slide-up"]    { transform: translateY(60px); }
+.layer-new [data-reveal="slide-down"]  { transform: translateY(-60px); }
+.layer-new [data-reveal="slide-left"]  { transform: translateX(-80px); }
+.layer-new [data-reveal="slide-right"] { transform: translateX(80px); }
+
+/* ---- diagonal sweep ---- */
+.layer-new [data-reveal="sweep-in"]    { transform: translate(-40px, 40px) rotate(-3deg); }
+
+/* ---- soft zoom ---- */
+.layer-new [data-reveal="zoom-in"]     { transform: scale(0.85); }
+.layer-new [data-reveal="zoom-out"]    { transform: scale(1.15); filter: blur(4px); }
+
+/* ---- 3D card flip ---- */
+.layer-new [data-reveal="flip-up"] {
+  transform: perspective(800px) rotateX(40deg) translateY(30px);
+  transform-origin: bottom center;
+}
+.layer-new [data-reveal="flip-left"] {
+  transform: perspective(800px) rotateY(25deg) translateX(-30px);
+  transform-origin: right center;
+}
+
+/* ---- wipe (clip-path based) ---- */
+.layer-new [data-reveal="wipe-right"]  { transform: translateY(4px); }
+.layer-new [data-reveal="wipe-up"]     { transform: translateY(4px); }
+.layer-new [data-reveal="wipe-center"] { transform: translateY(4px); }
+
+/* ---- spring pop ---- */
+.layer-new [data-reveal="pop"] { transform: scale(0.6); }
+
+/* ---- elastic drop (falls in from above, bounces) ---- */
+.layer-new [data-reveal="drop"] { transform: translateY(-90px) scale(0.95); }
+
+/* ---- spin-in ---- */
+.layer-new [data-reveal="spin-in"] { transform: rotate(-12deg) scale(0.9); }
+
+/* ---- stagger-fade (generic, used with delays) ---- */
+.layer-new [data-reveal="fade"] { /* just opacity, no transform */ }
+
+/* ---- revealed state (shared) ---- */
+.layer-new [data-reveal].revealed {
+  opacity: 1;
+  transform: none;
+  filter: none;
+  clip-path: none;
+}
+
+/* ---- keyframe overrides for animations that need bounce / spring ---- */
+
+.layer-new [data-reveal="pop"].revealed {
+  animation: rv-pop 650ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+@keyframes rv-pop {
+  0%   { opacity: 0; transform: scale(0.6); }
+  50%  { opacity: 1; transform: scale(1.08); }
+  75%  { transform: scale(0.97); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+.layer-new [data-reveal="drop"].revealed {
+  animation: rv-drop 700ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@keyframes rv-drop {
+  0%   { opacity: 0; transform: translateY(-90px) scale(0.95); }
+  55%  { opacity: 1; transform: translateY(8px) scale(1); }
+  72%  { transform: translateY(-4px); }
+  86%  { transform: translateY(2px); }
+  100% { opacity: 1; transform: none; }
+}
+
+.layer-new [data-reveal="flip-up"].revealed {
+  animation: rv-flip-up 700ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@keyframes rv-flip-up {
+  0%   { opacity: 0; transform: perspective(800px) rotateX(40deg) translateY(30px); }
+  50%  { opacity: 1; transform: perspective(800px) rotateX(-4deg) translateY(0); }
+  75%  { transform: perspective(800px) rotateX(2deg); }
+  100% { opacity: 1; transform: perspective(800px) rotateX(0deg); }
+}
+
+.layer-new [data-reveal="flip-left"].revealed {
+  animation: rv-flip-left 700ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@keyframes rv-flip-left {
+  0%   { opacity: 0; transform: perspective(800px) rotateY(25deg) translateX(-30px); }
+  50%  { opacity: 1; transform: perspective(800px) rotateY(-3deg) translateX(0); }
+  75%  { transform: perspective(800px) rotateY(1.5deg); }
+  100% { opacity: 1; transform: perspective(800px) rotateY(0deg); }
+}
+
+.layer-new [data-reveal="spin-in"].revealed {
+  animation: rv-spin 650ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@keyframes rv-spin {
+  0%   { opacity: 0; transform: rotate(-12deg) scale(0.9); }
+  60%  { opacity: 1; transform: rotate(2deg) scale(1.02); }
+  80%  { transform: rotate(-0.5deg) scale(1); }
+  100% { opacity: 1; transform: none; }
+}
+
+.layer-new [data-reveal="wipe-right"].revealed {
+  animation: rv-wipe-right 700ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+@keyframes rv-wipe-right {
+  0%   { opacity: 1; clip-path: inset(0 100% 0 0); transform: translateY(4px); }
+  100% { opacity: 1; clip-path: inset(0 0% 0 0);   transform: none; }
+}
+
+.layer-new [data-reveal="wipe-up"].revealed {
+  animation: rv-wipe-up 700ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+@keyframes rv-wipe-up {
+  0%   { opacity: 1; clip-path: inset(100% 0 0 0); transform: translateY(4px); }
+  100% { opacity: 1; clip-path: inset(0 0 0 0);    transform: none; }
+}
+
+.layer-new [data-reveal="wipe-center"].revealed {
+  animation: rv-wipe-center 700ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+@keyframes rv-wipe-center {
+  0%   { opacity: 1; clip-path: inset(0 50% 0 50%); transform: translateY(4px); }
+  100% { opacity: 1; clip-path: inset(0 0% 0 0%);   transform: none; }
+}
+
+/* ---- delay utilities ---- */
+.layer-new [data-reveal-delay="1"]  { transition-delay: 80ms;  animation-delay: 80ms; }
+.layer-new [data-reveal-delay="2"]  { transition-delay: 160ms; animation-delay: 160ms; }
+.layer-new [data-reveal-delay="3"]  { transition-delay: 240ms; animation-delay: 240ms; }
+.layer-new [data-reveal-delay="4"]  { transition-delay: 320ms; animation-delay: 320ms; }
+.layer-new [data-reveal-delay="5"]  { transition-delay: 400ms; animation-delay: 400ms; }
+.layer-new [data-reveal-delay="6"]  { transition-delay: 480ms; animation-delay: 480ms; }
+.layer-new [data-reveal-delay="7"]  { transition-delay: 560ms; animation-delay: 560ms; }
+.layer-new [data-reveal-delay="8"]  { transition-delay: 640ms; animation-delay: 640ms; }
+
+@media (prefers-reduced-motion: reduce) {
+  .layer-new [data-reveal] {
+    opacity: 1 !important;
+    transform: none !important;
+    filter: none !important;
+    clip-path: none !important;
+    transition: none !important;
+    animation: none !important;
+  }
+}
 
 @media (max-width: 900px) {
   .pin-btn {

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -660,7 +660,66 @@ body {
    JS sets inline transform + opacity directly. CSS just opts in. */
 
 
+/* ── Pin buttons ── */
+
+.pin-btn {
+  position: fixed;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 60;
+  width: 28px;
+  height: 28px;
+  border: 1.5px solid rgba(0, 0, 0, 0.45);
+  border-radius: 50%;
+  background: none;
+  color: rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  transition:
+    color 200ms ease,
+    border-color 200ms ease;
+  padding: 0;
+}
+
+.pin-btn:hover {
+  color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(0, 0, 0, 0.7);
+}
+
+.pin-btn--left {
+  left: 16px;
+}
+
+.pin-btn--right {
+  right: 16px;
+}
+
+.pin-btn.pinned {
+  color: var(--new-accent);
+  border-color: var(--new-accent);
+}
+
+.pin-btn .pin-icon {
+  display: block;
+  width: 10px;
+  height: 10px;
+  border: 1.5px solid currentColor;
+  border-radius: 50%;
+  transition: background 200ms ease;
+}
+
+.pin-btn.pinned .pin-icon {
+  background: currentColor;
+}
+
+
 @media (max-width: 900px) {
+  .pin-btn {
+    display: none;
+  }
   .layer .nav-toggle {
     display: none;
     visibility: hidden;

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -360,7 +360,7 @@ body {
 }
 
 .layer-new .nav-header {
-  margin: 0 2em;
+  margin: 0 32px;
   background: rgba(6, 18, 27, 0.84);
   border-bottom: 1px solid rgba(69, 217, 255, 0.25);
   border-bottom-left-radius: 14px;
@@ -480,7 +480,7 @@ body {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.01));
   border: 1px solid rgba(69, 217, 255, 0.25);
   border-radius: 14px;
-  padding: 1.2rem;
+  padding: 16px;
   box-shadow: 0 16px 28px rgba(0, 0, 0, 0.22);
 }
 
@@ -682,8 +682,8 @@ body {
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: flex-end;
-    gap: 0.25rem 0.65rem;
-    padding: 0.25rem 0;
+    gap: 8px 8px;
+    padding: 8px 0;
   }
 
   .layer .nav__item {
@@ -724,6 +724,6 @@ body {
 
   .layer-new .nav-header,
   .layer-old .nav-header {
-    margin-top: 0.6rem;
+    margin-top: 8px;
   }
 }

--- a/static/js/site.js
+++ b/static/js/site.js
@@ -17,11 +17,14 @@
   var layerNew = wrapper.querySelector(".layer-new");
   var neutralZone = wrapper.querySelector(".neutral-zone");
   var activeSide = "";
+  var pinnedSide = "";
   var isMobile = window.matchMedia("(max-width: 900px)").matches;
   var hasHover = window.matchMedia("(hover: hover)").matches;
   var neutralZoneHalfWidth = 110;
   var navToggles = document.querySelectorAll(".nav-toggle");
   var navLinks = document.querySelectorAll(".nav__link");
+  var pinLeft = document.getElementById("pin-left");
+  var pinRight = document.getElementById("pin-right");
 
   function updateNeutralZoneWidth() {
     var rootStyles = window.getComputedStyle(document.documentElement);
@@ -62,6 +65,10 @@
       return;
     }
 
+    if (pinnedSide) {
+      return;
+    }
+
     if (side === activeSide) {
       return;
     }
@@ -70,6 +77,24 @@
     wrapper.classList.toggle("hover-left", side === "left");
     wrapper.classList.toggle("hover-right", side === "right");
     wrapper.classList.toggle("hover-center", side === "center");
+  }
+
+  function pinSide(side) {
+    if (pinnedSide === side) {
+      pinnedSide = "";
+      pinLeft.classList.remove("pinned");
+      pinRight.classList.remove("pinned");
+      return;
+    }
+
+    pinnedSide = side;
+    pinLeft.classList.toggle("pinned", side === "left");
+    pinRight.classList.toggle("pinned", side === "right");
+
+    activeSide = side;
+    wrapper.classList.toggle("hover-left", side === "left");
+    wrapper.classList.toggle("hover-right", side === "right");
+    wrapper.classList.remove("hover-center");
   }
 
   function onPointerMove(event) {
@@ -90,6 +115,9 @@
     updateNeutralZoneWidth();
     syncContainerHeight();
     if (isMobile || !hasHover) {
+      pinnedSide = "";
+      pinLeft && pinLeft.classList.remove("pinned");
+      pinRight && pinRight.classList.remove("pinned");
       clearState();
     }
   }
@@ -134,16 +162,33 @@
     });
   });
 
+  if (pinLeft) {
+    pinLeft.addEventListener("click", function (event) {
+      event.stopPropagation();
+      pinSide("left");
+    });
+  }
+
+  if (pinRight) {
+    pinRight.addEventListener("click", function (event) {
+      event.stopPropagation();
+      pinSide("right");
+    });
+  }
+
   document.addEventListener("keydown", function (event) {
     if (event.key === "ArrowLeft") {
-      setSide("left");
+      pinSide("left");
     }
 
     if (event.key === "ArrowRight") {
-      setSide("right");
+      pinSide("right");
     }
 
     if (event.key === "Escape") {
+      pinnedSide = "";
+      pinLeft && pinLeft.classList.remove("pinned");
+      pinRight && pinRight.classList.remove("pinned");
       clearState();
     }
   });

--- a/static/js/site.js
+++ b/static/js/site.js
@@ -197,4 +197,24 @@
   updateNeutralZoneWidth();
   window.setTimeout(syncContainerHeight, 250);
 
+  var revealTargets = document.querySelectorAll(".layer-new [data-reveal]");
+
+  if (revealTargets.length > 0 && "IntersectionObserver" in window) {
+    var revealThreshold = window.matchMedia("(max-width: 900px)").matches ? 0.05 : 0.12;
+
+    var revealObserver = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("revealed");
+        } else {
+          entry.target.classList.remove("revealed");
+        }
+      });
+    }, { threshold: revealThreshold });
+
+    revealTargets.forEach(function (el) {
+      revealObserver.observe(el);
+    });
+  }
+
 })();

--- a/static/styles.css
+++ b/static/styles.css
@@ -59,7 +59,7 @@ body {
 }
 
 section {
-  padding: 5em 2em;
+  padding: 128px 64px;
 }
 
 img {
@@ -79,7 +79,7 @@ strong {
 
 .btn {
   display: inline-block;
-  padding: 0.5em 2.5em;
+  padding: 8px 32px;
   background: var(--clr-accent);
   color: var(--clr-dark);
   text-decoration: none;
@@ -118,7 +118,7 @@ h3 {
 }
 
 .section__title {
-  margin-bottom: 0.25em;
+  margin-bottom: 8px;
 }
 
 .section__title--intro {
@@ -246,16 +246,15 @@ h3 {
 .section__subtitle--work {
   color: var(--clr-accent);
   font-weight: var(--fw-bold);
-  margin-bottom: 2em;
+  margin-bottom: 32px;
 }
 
 .section__subtitle--intro,
 .section__subtitle--about {
   background: var(--clr-accent);
   font-family: var(--ff-secondary);
-  margin-bottom: 1em;
-  padding: 0.25em 1em;
-  margin-bottom: 1em;
+  margin-bottom: 16px;
+  padding: 8px 16px;
 }
 
 /* header */
@@ -263,8 +262,7 @@ h3 {
 header {
   display: flex;
   justify-content: space-between;
-  padding-right: 1em;
-  padding-left: 1em;
+  padding: 0 16px;
 }
 
 .logo {
@@ -272,8 +270,8 @@ header {
 }
 
 .nav-header {
-  margin: 0 2em;
-  padding: 5px;
+  margin: 0 32px;
+  padding: 8px;
   background: white;
   border-bottom-left-radius: 15px;
   border-bottom-right-radius: 15px;
@@ -287,8 +285,8 @@ header {
   font-weight: var(--fw-bold);
   font-size: var(--fs-h2);
   text-decoration: none;
-  margin: 4rem auto;
-  margin-right: 2rem;
+  margin: 32px auto;
+  margin-right: 32px;
 }
 
 .nav__link:hover {
@@ -322,13 +320,13 @@ header {
 @media (max-width: 1100px) {
   .nav-toggle {
     visibility: visible;
-    padding: 0.5em;
+    padding: 8px;
     background: transparent;
     border: 0;
     cursor: pointer;
     position: absolute;
-    right: 1em;
-    top: 1em;
+    right: 16px;
+    top: 16px;
     z-index: 1000;
   }
 
@@ -359,7 +357,7 @@ header {
   }
 
   .nav-open .nav__item {
-    padding: 1em;
+    padding: 16px;
   }
 
   .nav-open .nav-toggle {
@@ -419,8 +417,8 @@ header {
   text-align: center;
   font-size: var(--fs-h3);
   color: var(--clr-accent);
-  margin-top: -2em;
-  margin-bottom: 4em;
+  margin-top: -32px;
+  margin-bottom: 32px;
 }
 
 .intro__img {
@@ -432,7 +430,7 @@ header {
     display: grid;
     width: min-content;
     margin: 0 auto;
-    grid-column-gap: 1em;
+    grid-column-gap: 16px;
     grid-template-areas:
       "img title"
       "img subtitle";
@@ -452,8 +450,8 @@ header {
     grid-row: 2;
     text-align: right;
     position: relative;
-    left: -1.5rem;
-    width: calc(100% + 1.5em);
+    left: -16px;
+    width: calc(100% + 16px);
   }
 }
 
@@ -485,13 +483,13 @@ header {
   display: block;
   width: 65%;
   height: 1px;
-  margin: 0.5em auto 1em;
+  margin: 8px auto 16px;
   background: var(--clr-light);
   opacity: 0.25;
 }
 
 .services {
-  margin-bottom: 4em;
+  margin-bottom: 32px;
 }
 
 .service {
@@ -509,18 +507,18 @@ header {
   }
 
   .service + .service {
-    margin-left: 2em;
+    margin-left: 32px;
   }
 }
 @media (max-width: 1000px) {
   .service {
-    margin: 4rem auto;
+    margin: 32px auto;
   }
 }
 @media (max-width: 600px) {
   .service {
     width: 75vw;
-    margin: 4rem auto;
+    margin: 32px auto;
   }
 }
 .fade-up-container {
@@ -563,7 +561,7 @@ header {
   width: 48px;
   text-align: center;
   list-style: none;
-  margin: 0.25em auto;
+  margin: 8px auto;
 }
 
 .tech-stack img {
@@ -601,7 +599,7 @@ header {
       "subtitle img"
       "text img"
       "tech img";
-    grid-column-gap: 2em;
+    grid-column-gap: 32px;
   }
 
   .section__title--about {
@@ -612,10 +610,10 @@ header {
     grid-column: 1 / -1;
     grid-row: 2;
     position: relative;
-    left: -1em;
-    width: calc(100% + 2em);
-    padding-left: 1em;
-    padding-right: calc(200px + 4em);
+    left: -16px;
+    width: calc(100% + 32px);
+    padding-left: 16px;
+    padding-right: calc(200px + 32px);
   }
 
   .about-me__img {
@@ -637,7 +635,7 @@ header {
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   max-width: 1000px;
   margin: 0 auto;
-  gap: 5px;
+  gap: 8px;
 }
 
 .portfolio-page img {
@@ -664,8 +662,8 @@ header {
 
 .portfolio__text {
   position: absolute;
-  left: 2rem;
-  top: 2rem;
+  left: 32px;
+  top: 32px;
   color: white;
   font-size: var(--fs-h3);
   text-shadow: 2px 2px 5px var(--clr-dark);
@@ -734,7 +732,7 @@ a {
 }
 
 .roadmap__item {
-  padding: 4em;
+  padding: 32px;
 }
 
 /* Footer */
@@ -743,7 +741,7 @@ a {
   background: #1d1d1d;
   color: var(--clr-accent);
   text-align: center;
-  padding: 2.5em 0;
+  padding: 32px 0;
 }
 
 .footer a {
@@ -777,20 +775,20 @@ a {
   list-style: none;
   display: flex;
   justify-content: center;
-  margin: 2em 0;
+  margin: 32px 0;
   padding: 0;
 }
 
 .social-list__item {
-  margin: 0 0.5em;
+  margin: 0 8px;
 }
 
 .social-list__link {
-  padding: 0.5em;
+  padding: 8px;
 }
 
 .portfolio-item-individual {
-  padding: 0 2em 2em;
+  padding: 0 32px 32px;
   max-width: 75%;
   margin: 0 auto;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -218,20 +218,20 @@
         </header>
         <section class="intro fade-down" id="home-new">
           <div class="section__title section__title--intro typewriter-container">
-            <h1 class="typewriter head">Now shipping with</h1>
-            <h1 class="typewriter sub">Liel Ben-Or</h1>
+            <h1 class="typewriter head" data-reveal="wipe-right">Hi, I am</h1>
+            <h1 class="typewriter sub" data-reveal="slide-right" data-reveal-delay="2">Liel Ben-Or</h1>
           </div>
-          <p class="section__subtitle section__subtitle--intro">AI-first full-stack engineer</p>
-          <img class="intro__img" src="/static/img/me.png" alt="" />
+          <p class="section__subtitle section__subtitle--intro" data-reveal="slide-up" data-reveal-delay="3">Full Stack Developer</p>
+          <img class="intro__img" src="/static/img/me.png" alt="" data-reveal="zoom-in" data-reveal-delay="1" />
         </section>
-        <div class="greeting"><p>Building products, agents, and systems that learn.</p></div>
+        <div class="greeting" data-reveal="fade"><p>I build things that work. Then I rebuild them better.</p></div>
         <section class="my-services" id="services-new">
           <div class="fade-up-container">
-            <h2 class="section__title section__title--services">What I build now</h2>
+            <h2 class="section__title section__title--services" data-reveal="wipe-center">What I bring to the table</h2>
             <div class="services">
-              <div class="service">
-                <h3>AI Backends</h3>
-                <p>Inference pipelines, retrieval APIs, and production-grade service orchestration.</p>
+              <div class="service" data-reveal="flip-up" data-reveal-delay="1">
+                <h3>Backend &amp; AI</h3>
+                <p>From REST APIs to inference pipelines — I build the systems behind the product.</p>
                 <ul class="tech-stack">
                   <li class="tech-stack__item"><img alt="" src="/static/img/tech-stack/java.png" /></li>
                   <li class="tech-stack__item"><img alt="" src="/static/img/tech-stack/python.png" /></li>
@@ -242,9 +242,9 @@
                   <li class="tech-stack__item"><img alt="" src="/static/img/tech-stack/git.png" /></li>
                 </ul>
               </div>
-              <div class="service">
-                <h3>Modern Frontend</h3>
-                <p>High-performance interfaces for workflows, copilots, and real-time feedback loops.</p>
+              <div class="service" data-reveal="flip-left" data-reveal-delay="2">
+                <h3>Frontend</h3>
+                <p>Interfaces that earn trust. If the user has to think about the UI, I've failed.</p>
                 <ul class="tech-stack">
                   <li class="tech-stack__item"><img alt="" src="/static/img/tech-stack/html.png" /></li>
                   <li class="tech-stack__item"><img alt="" src="/static/img/tech-stack/css.png" /></li>
@@ -255,9 +255,9 @@
                   <li class="tech-stack__item"><img alt="" src="/static/img/tech-stack/babel.png" /></li>
                 </ul>
               </div>
-              <div class="service">
-                <h3>Platform and MLOps</h3>
-                <p>Cloud automation, CI/CD, observability, and resilient deployment systems.</p>
+              <div class="service" data-reveal="sweep-in" data-reveal-delay="3">
+                <h3>Infra &amp; Ops</h3>
+                <p>CI/CD, cloud, monitoring. The unglamorous work that makes everything else possible.</p>
                 <ul class="tech-stack">
                   <li class="tech-stack__item"><img alt="" class="tech-stack__img" src="/static/img/tech-stack/aws.png" /></li>
                   <li class="tech-stack__item"><img alt="" class="tech-stack__img" src="/static/img/tech-stack/azuredevops.png" /></li>
@@ -266,66 +266,66 @@
               </div>
             </div>
           </div>
-          <a href="#work-new" class="btn btn-blue">See Recent Work</a>
+          <a href="#work-new" class="btn btn-blue" data-reveal="pop" data-reveal-delay="4">See my work</a>
         </section>
         <section class="about-me" id="about-me-new">
-          <h2 class="section__title section__title--about">Who I am</h2>
-          <p class="section__subtitle section__subtitle--about">Engineer, builder, and systems thinker</p>
-          <div class="about-me__body">
-            <p>I pair formal computer science foundations with rapid product execution, from architecture to polished UX.</p>
-            <p>My focus is on practical AI software: agentic workflows, retrieval systems, and full-stack products users actually keep.</p>
-            <p>Still curious, still shipping, and still improving every release.</p>
+          <h2 class="section__title section__title--about" data-reveal="slide-down">Who I am</h2>
+          <p class="section__subtitle section__subtitle--about" data-reveal="slide-right" data-reveal-delay="1">Engineer who ships</p>
+          <div class="about-me__body" data-reveal="slide-left" data-reveal-delay="2">
+            <p>I studied computer science at the Open University of Israel and never stopped learning after that.</p>
+            <p>These days I work across the full stack — from system design to polished UI — with a focus on AI-powered products.</p>
+            <p>I care about the craft. Even the parts no one sees.</p>
           </div>
-          <img src="/static/img/icon192.png" alt="" class="about-me__img" />
+          <img src="/static/img/icon192.png" alt="" class="about-me__img" data-reveal="spin-in" data-reveal-delay="2" />
         </section>
         <section class="my-work" id="work-new">
-          <h2 class="section__title section__title--work">Selected Builds</h2>
-          <p class="section__subtitle section__subtitle--work">From classic apps to AI-native products</p>
+          <h2 class="section__title section__title--work" data-reveal="wipe-up">Selected work</h2>
+          <p class="section__subtitle section__subtitle--work" data-reveal="slide-left" data-reveal-delay="1">Things I've built</p>
           <div class="portfolio">
-            <a href="projects/popsi-colada.html" class="portfolio__item">
+            <a href="projects/popsi-colada.html" class="portfolio__item" data-reveal="pop" data-reveal-delay="1">
               <img src="/static/img/projects/popsi-colada.png" alt="" class="portfolio__img" />
               <span class="portfolio__text">Popsi Colada</span>
             </a>
-            <a href="projects/angular-file-generator.html" class="portfolio__item">
+            <a href="projects/angular-file-generator.html" class="portfolio__item" data-reveal="slide-up" data-reveal-delay="2">
               <img src="/static/img/projects/angular-file-generator-main.png" width="100%" alt="" class="portfolio__img" />
               <span class="portfolio__text">Angular File Generator</span>
             </a>
-            <a href="projects/network.html" class="portfolio__item">
+            <a href="projects/network.html" class="portfolio__item" data-reveal="flip-up" data-reveal-delay="3">
               <img src="/static/img/projects/network.png" width="100%" alt="" class="portfolio__img" />
               <span class="portfolio__text">Network</span>
             </a>
-            <a href="projects/commerce.html" class="portfolio__item">
+            <a href="projects/commerce.html" class="portfolio__item" data-reveal="sweep-in" data-reveal-delay="1">
               <img src="/static/img/projects/commerce.png" alt="" class="portfolio__img" />
               <span class="portfolio__text">Commerce</span>
             </a>
-            <a href="projects/wiki.html" class="portfolio__item">
+            <a href="projects/wiki.html" class="portfolio__item" data-reveal="zoom-out" data-reveal-delay="2">
               <img src="/static/img/projects/wiki.png" alt="" class="portfolio__img" />
               <span class="portfolio__text">Wiki</span>
             </a>
-            <a href="projects/weekly-planner.html" class="portfolio__item">
+            <a href="projects/weekly-planner.html" class="portfolio__item" data-reveal="drop" data-reveal-delay="3">
               <img src="/static/img/projects/extension.png" alt="" class="portfolio__img" />
               <span class="portfolio__text">Weekly Planner</span>
             </a>
-            <a href="projects/fractals.html" class="portfolio__item">
+            <a href="projects/fractals.html" class="portfolio__item" data-reveal="flip-left" data-reveal-delay="4">
               <img src="/static/img/projects/fractals-main.png" alt="" class="portfolio__img portfolio__item-mobile" />
               <span class="portfolio__text">Fractals</span>
             </a>
-            <div class="portfolio__item">
+            <div class="portfolio__item" data-reveal="spin-in" data-reveal-delay="5">
               <p>Planned project:</p>
               <p>Sudoku solver</p>
             </div>
           </div>
-          <p>More experiments and production launches are in progress.</p>
+          <p data-reveal="fade">More on the way. Always.</p>
         </section>
         <section class="resume" id="resume-new">
-          <h2 class="section__title section__title--resume">My resume</h2>
-          <div class="embed-resume">
+          <h2 class="section__title section__title--resume" data-reveal="slide-down">My resume</h2>
+          <div class="embed-resume" data-reveal="pop" data-reveal-delay="1">
             <a href="/static/img/liel_ben_or_resume.pdf" target="_blank">View resume<span style="margin-right: 0.25em"></span><i class="fas fa-external-link-alt"></i></a>
           </div>
         </section>
         <footer class="footer">
-          <a href="mailto:liel4349@gmail.com" class="footer__link"><i class="fa fa-envelope" aria-hidden="true"></i> Contact Me</a>
-          <ul class="social-list">
+          <a href="mailto:liel4349@gmail.com" class="footer__link" data-reveal="slide-up"><i class="fa fa-envelope" aria-hidden="true"></i> Contact Me</a>
+          <ul class="social-list" data-reveal="slide-right" data-reveal-delay="1">
             <li class="social-list__link"><a href="https://github.com/lebnor"><i class="fab fa-github"> github</i></a></li>
             <li class="social-list__link"><a href="https://www.linkedin.com/in/liel-ben-or-145b64189/"><i class="fab fa-linkedin-in"> linked-in</i></a></li>
           </ul>

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,6 +40,12 @@
   </svg>
 
   <div class="prototype-wrapper" id="prototype-wrapper">
+    <button class="pin-btn pin-btn--left" id="pin-left" aria-label="Pin old style" title="Pin this style">
+      <span class="pin-icon"></span>
+    </button>
+    <button class="pin-btn pin-btn--right" id="pin-right" aria-label="Pin new style" title="Pin this style">
+      <span class="pin-icon"></span>
+    </button>
     <div class="neutral-zone" aria-hidden="true">
       <div class="glitch-bar gb1"></div>
       <div class="glitch-bar gb2"></div>


### PR DESCRIPTION
## Summary
- Adds IntersectionObserver-based scroll-reveal animation system for `.layer-new` only
- 16 unique animation variants (slide, wipe, flip, pop, drop, spin, sweep, zoom, fade) for varied movement across sections
- Animations replay every time elements re-enter the viewport on scroll
- Updated new layer subtitle copy to "Full Stack Developer"
- `prefers-reduced-motion` support included