### PR TITLE
Fix Vercel deploy: switch from Python to static serving

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,15 +1,5 @@
 {
   "version": 2,
-  "builds": [
-    {
-      "src": "./app.py",
-      "use": "@vercel/python"
-    }
-  ],
-  "routes": [
-    {
-      "src": "/(.*)",
-      "dest": "app.py"
-    }
-  ]
+  "framework": null,
+  "outputDirectory": "."
 }


### PR DESCRIPTION
## Summary
- `vercel.json` was configured to run Flask via `@vercel/python`, causing dependency resolution failures
- Switched to static file serving since `index.html` now exists at root
- No build step needed — Vercel serves files directly